### PR TITLE
fix(nav): shrinking the nav content to 100% of the content width

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -3,6 +3,10 @@ header {
   background-color: white;
 }
 
+.header.block.nav-wrapper {
+  box-shadow: 2px 2px 10px 1px rgba(0 0 0 / 15%);
+}
+
 .header.block nav {
   position: relative;
   display: grid;
@@ -16,7 +20,6 @@ header {
     / min-content 1fr min-content;
   justify-content: space-between;
   background-color: transparent;
-  box-shadow: 2px 2px 10px 1px rgba(0 0 0 / 15%);
 }
 
 .header.block nav[aria-expanded="true"] {
@@ -377,4 +380,6 @@ header {
   .header.block .nav-sections > ul > li > ul > li.hide {
     display: none;
   }
+
+
 }


### PR DESCRIPTION
modifying the css rule for the nav-wrapper and nav elements to allow for the background of the nav to be full viewport width, but the nav itself to shrink to the page content width. See the [1800px image](#1800px) below for the real demonstration.

fix #47 

Test URLs:
- Before: https://main--takeda-ihs--hlxsites.hlx.page/
- After: https://<branch>--takeda-ihs--hlxsites.hlx.page/


## 300 px

I didn't style the page content for this test, but you can see the nav and footer respecting the viewport width.

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/54caf94d-b5a4-427b-9396-38bf94a74ea6)


## 600 px

Same as 300px

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/6c0f876a-7973-4873-8211-5223b028b837)


## 900 px

Same as 300 px

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/fb707c0f-361b-4de9-866e-0ea88b595012)


## 1200 px

Same as 300 px

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/8856c4c9-e8d1-46d7-863f-816eb2e8fc0f)


## 1800px<a id="1800px"></a>

Notice the margins without the box-shadow.

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/49140ea2-2e0a-4a7a-be29-9ee4cbef483e)



