### PR TITLE
feat(calendar events): adding a calendar events block

### DIFF
--- a/blocks/calendar-events/calendar-events.css
+++ b/blocks/calendar-events/calendar-events.css
@@ -1,0 +1,145 @@
+.calendar-events.block {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    justify-items: center;
+    gap: 28px;
+    margin: 0 auto;
+}
+
+.calendar-events.block .calendar-event {
+    border: solid 1px transparent;
+    border-radius: 10px;
+    box-shadow: 0 4px 4px var(--gray-box-shadow);
+    width: 100%;
+}
+
+.calendar-events.block .calendar-event > .event-card {
+    padding: 20px 26px;
+
+}
+
+.calendar-events.block .calendar-event > .event-card p:first-of-type {
+    color: var(--gray);
+    font-size: var(--body-font-size-s);
+    text-transform: uppercase;
+    line-height: 14px;
+    margin: 0;
+}
+
+.calendar-events.block .calendar-event > .event-card p:nth-of-type(2) {
+    color: var(--black);
+    font-size: var(--body-font-size-m);
+    font-weight: var(--font-weight-bold);
+    line-height: 22px;
+    margin-bottom: 10px;
+}
+
+.calendar-events.block .calendar-event > .event-card > div:first-of-type {
+    margin-bottom: 10px;
+}
+
+.calendar-events.block .calendar-event > .event-card > div:nth-of-type(2) {
+    color: var(--default-text-color);
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-xs);
+    line-height: 17px;
+}
+
+.calendar-events.block .calendar-event > .date-card {
+    display: grid;
+    grid-template-columns: 80px auto;
+    padding: 20px;
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:first-of-type {
+    background: var(--red);
+    height: 64px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 14px 0 0;
+    border: solid 1px transparent;
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:first-of-type > h3,
+.calendar-events.block .calendar-event > .date-card  > div:first-of-type > p {
+    color: var(--white);
+    font-weight: var(--font-weight-bold);
+    line-height: 22px;
+    margin: 0;
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:first-of-type > h3 {
+    font-size: var(--body-font-size-xxl);
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:first-of-type > p {
+    font-size: var(--body-font-size-s);
+    text-transform: uppercase;
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:nth-of-type(2) {
+    font-family: var(--body-font-family);
+    font-size: var(--body-font-size-m);
+    line-height: 22px;
+}
+
+.calendar-events.block .calendar-event > .date-card  > div:nth-of-type(2) > p {
+    font-size: var(--body-font-size-l);
+}
+
+@media screen and (max-width: 300px){
+    .calendar-events.block {
+        width: 340px;
+    }
+}
+
+@media screen and (min-width: 600px){
+    .calendar-events.block {
+        width: 550px;
+    }
+}
+
+@media screen and (min-width: 900px){
+    .calendar-events.block {
+        width: 740px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card p:first-of-type {
+        font-size: var(--body-font-size-l);
+        line-height: 21px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card p:nth-of-type(2) {
+        font-size: var(--body-font-size-xxl);
+        line-height: 30px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card > div:nth-of-type(2) {
+        font-size: var(--body-font-size-l);
+        line-height: 23px;
+    }
+}
+
+@media screen and (min-width: 1200px){
+    .calendar-events.block {
+        width: 343px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card p:first-of-type {
+        font-size: var(--body-font-size-s);
+        line-height: 14px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card p:nth-of-type(2) {
+        font-size: var(--body-font-size-m);
+        line-height: 22px;
+    }
+
+    .calendar-events.block .calendar-event > .event-card > div:nth-of-type(2) {
+        font-size: var(--body-font-size-xs);
+        line-height: 17px;
+    }
+}

--- a/blocks/calendar-events/calendar-events.css
+++ b/blocks/calendar-events/calendar-events.css
@@ -90,23 +90,7 @@
     font-size: var(--body-font-size-l);
 }
 
-@media screen and (max-width: 300px){
-    .calendar-events.block {
-        width: 340px;
-    }
-}
-
-@media screen and (min-width: 600px){
-    .calendar-events.block {
-        width: 550px;
-    }
-}
-
 @media screen and (min-width: 900px){
-    .calendar-events.block {
-        width: 740px;
-    }
-
     .calendar-events.block .calendar-event > .event-card p:first-of-type {
         font-size: var(--body-font-size-l);
         line-height: 21px;
@@ -124,10 +108,6 @@
 }
 
 @media screen and (min-width: 1200px){
-    .calendar-events.block {
-        width: 343px;
-    }
-
     .calendar-events.block .calendar-event > .event-card p:first-of-type {
         font-size: var(--body-font-size-s);
         line-height: 14px;

--- a/blocks/calendar-events/calendar-events.js
+++ b/blocks/calendar-events/calendar-events.js
@@ -1,0 +1,21 @@
+import { decorateIcons } from '../../scripts/lib-franklin.js';
+
+export default async function decorate(block) {
+  block.classList.add(`calendar-events-${block.children.length}`);
+
+  [...block.children].forEach((row) => {
+    row.classList.add('calendar-event');
+    const decoration = row.children[0].textContent;
+    const dateOrHeading = row.children[1];
+    const description = row.children[2];
+    const contentContainer = document.createElement('div');
+
+    const className = decoration ? decoration.replaceAll(/(\s|-|:)+/g, '-') : 'event-card';
+
+    contentContainer.classList.add(className);
+    contentContainer.append(dateOrHeading, description);
+    row.replaceChildren(contentContainer);
+  });
+
+  await decorateIcons(block);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -52,6 +52,7 @@
   /* Colors */
   --bright-gray: #efefef;
   --gray: #979797;
+  --gray-box-shadow: rgb(0 0 0 / 20%);
   --silver: #d8d8d8;
   --quartz: #4c4948;
   --red: #e10;


### PR DESCRIPTION
Adding the calendar block.  If the width of the block should not be `100%` for smaller view widths, I can explicitly set those widths.

Fix #18

There is a current issue with the `floating images` block that affects this block.  The 2nd `After` URL is what this block will look like after that issue is resolved.

Test URLs:
- Before: https://main--takeda-ihs--hlxsites.hlx.page/
- After: https://feat-calendar-events--takeda-ihs--hlxsites.hlx.page/drafts/lwintch/calendar-events
- After (working around current floating images issue): https://feat-calendar-events-workaround--takeda-ihs--hlxsites.hlx.page/drafts/lwintch/calendar-events
