### PR TITLE
feat(angle background): adding the angle background where the bottom …

### DIFF
--- a/blocks/lists/lists.css
+++ b/blocks/lists/lists.css
@@ -139,7 +139,6 @@
         font-size: var(--body-font-size-s);
     }
 
-
     .lists.triple-aim.block > div > div > h2 {
         font-size: var(--heading-font-size-l);
     }
@@ -148,10 +147,6 @@
         align-items: center;
         grid-template-columns: 2fr 3fr;
         gap: 16px;
-    }
-
-    .lists.triple-aim.block {
-        max-width: 740px;
     }
 }
 
@@ -166,9 +161,5 @@
 
     .lists.triple-aim.block > div > div > h2 {
         font-size: var(--heading-font-size-l);
-    }
-
-    .lists.triple-aim.block {
-        max-width: 980px;
     }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -128,7 +128,7 @@
   --gray-gradient-breakpoint: 41%;
 
   /* Gradient angles */
-  --gray-gradient-angle: -172.8750deg;
+  --gray-gradient-angle: -180deg;
 }
 
 *, *::before, *::after {
@@ -338,6 +338,75 @@ main .section.gray-gradient {
   );
 }
 
+.angle-background-top,
+.angle-background-top-s,
+.angle-background-top-l {
+  background: var(--white);
+}
+
+.section .angle-background-top::after,
+.section .angle-background-top-s::after {
+  background: var(--gray-gradient-light);
+  clip-path: polygon(0 100%, 100% 5vw, 100% 0, 0 100%);
+  content: '';
+  display: block;
+  height: 5vw;
+  margin-bottom: -1px;
+  padding-bottom: 5vw;
+  width: 100%;
+}
+
+.section .angle-background-top-l::after {
+  background: var(--gray-gradient-light);
+  clip-path: polygon(0 100%, 100% 10vw, 100% 0, 0 100%);
+  content: '';
+  display: block;
+  height: 10vw;
+  margin-bottom: -1px;
+  padding-bottom: 10vw;
+  width: 100%;
+}
+
+.section.angle-background,
+.section.angle-background-top,
+.section.angle-background-top-s,
+.section.angle-background-top-l {
+  padding-bottom: unset;
+}
+
+.section.angle-background-top::after,
+.section.angle-background-top-s::after {
+  background: var(--gray-gradient-light);
+  clip-path: polygon(0 100%, 100% 5vw, 100% 0, 0 100%);
+  content: '';
+  display: block;
+  height: 5vw;
+  margin-bottom: -1px;
+  padding-bottom: 5vw;
+  width: 100%;
+
+}
+
+.section.angle-background-top-l::after {
+  background: var(--gray-gradient-light);
+  clip-path: polygon(0 100%, 100% 10vw, 100% 0, 0 100%);
+  content: '';
+  display: block;
+  height: 10vw;
+  margin-bottom: -1px;
+  padding-bottom: 5vw;
+  width: 100%;
+}
+
+.angle-background {
+  background: linear-gradient(
+          var(--gray-gradient-angle),
+          var(--gray-gradient-light) 0%,
+          var(--gray-gradient-light) var(--gray-gradient-breakpoint),
+          var(--gray-gradient-dark) 100%
+  );
+}
+
 .sr-only {
   position: absolute;
   left: -10000px;
@@ -361,6 +430,7 @@ main .section.gray-gradient {
   main > .section > div {
     padding: 0 24px;
   }
+
 }
 
 @media screen and (min-width: 900px) {
@@ -380,13 +450,11 @@ main .section.gray-gradient {
     padding: 0 90px;
   }
 
-
   main .section[data-layout="50/50"] .layout-content-wrapper {
     flex-flow: row wrap;
     align-items: center;
     column-gap: 3em;
   }
-
 
   main .section[data-layout="50/50"] .layout-content-wrapper > div {
     flex-basis: calc(50% - 1.5em);
@@ -399,7 +467,6 @@ main .section.gray-gradient {
   main .section[data-layout] .default-content-wrapper p {
     font-size: var(--body-font-size-s);
   }
-
 }
 
 @media screen and (min-width: 1200px) {


### PR DESCRIPTION
…half is the light gray color.  Works on blocks and sections.

eg 

| Section Metadata  |  |
|---|---|
| Style | angle-background-top |

------ New Section ----

| Section Metadata  |  |
|---|---|
| Style | angle-background |

Possible values for the css classname that denotes the top element are `angle-background-top`|`angle-background-top-s`|`angle-background-top-l`.  The `top` and `top-s` are the same.

These values can also be applied to a named block and behave the same.

Fix #11 

Test URLs:
- After: https://feat-angle-section-background--takeda-ihs--hlxsites.hlx.page/drafts/lwintch/angle-section-background
