### PR TITLE
fix(cuvitro hero style): changing the button bg color to match prod

### DIFF
--- a/blocks/hero/product-hero.css
+++ b/blocks/hero/product-hero.css
@@ -113,7 +113,8 @@
 }
 
 .block.hero.cuvitru .link .button-container a {
-  color: var(--cuvitru);
+  background-color: var(--cuvitru);
+  color: var(--white);
 }
 
 .block.hero.flexbumin .link .button-container a {


### PR DESCRIPTION
changed the "download pdf" button to match the live site as the darker background color and white text

fix #130

Test URLs:

Please note, for testing urls, make sure to include the `lighthouse=on` URL parameter to bypass the Modal, and get the correct PSI Score.


- Before: https://main--takeda-ihs--hlxsites.hlx.page/products/cuvitru?=lighthouse=on
- After: https://fix-130-cuvitro-button--takeda-ihs--hlxsites.hlx.page/products/cuvitru?=lighthouse=on

## Before

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/bd1cf10a-2bbe-4336-bf1d-d0f609f407de)


## After

![image](https://github.com/hlxsites/takeda-ihs/assets/5343448/ca10d9f7-f528-4d98-bd1e-922ca5c29a65)

