### PR TITLE
removing the word download from the hero card button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Takeda Integrated Health Systems
 
 ## Environments
 
--Preview: https://remove-hardcoded-text-from-hero-card--takeda-ihs--hlxsites.hlx.page/
+-Preview: https://main--takeda-ihs--hlxsites.hlx.page/
 
--Live: https://remove-hardcoded-text-from-hero-card--takeda-ihs--hlxsites.hlx.live/
+-Live: https://main--takeda-ihs--hlxsites.hlx.live/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Takeda Integrated Health Systems
 
 ## Environments
 
--Preview: https://main--takeda-ihs--hlxsites.hlx.page/
+-Preview: https://remove-hardcoded-text-from-hero-card--takeda-ihs--hlxsites.hlx.page/
 
--Live: https://main--takeda-ihs--hlxsites.hlx.live/
+-Live: https://remove-hardcoded-text-from-hero-card--takeda-ihs--hlxsites.hlx.live/
 
 ## Installation
 

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -80,10 +80,7 @@ function buildCardContent(block) {
       const name = document.createElement('p');
       name.classList.add('name');
       name.textContent = text;
-      const download = document.createElement('p');
-      download.classList.add('download');
-      download.textContent = 'Download';
-      wrapper.append(name, download);
+      wrapper.append(name);
       a.replaceChildren(wrapper);
     });
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

This is to resolve issue #159   Phase 1A Remove hardcoded text from hero card #158



Test URLs:

Please note, for testing urls, make sure to include the `lighthouse=on` URL parameter to bypass the Modal, and get the correct PSI Score.


- After: https://remove-hardcoded-text-from-hero-card--takeda-ihs--hlxsites.hlx.page/?lighthouse=on
